### PR TITLE
Assign lang upon the creation of the testing element

### DIFF
--- a/test/jquery.webfonts.test.js
+++ b/test/jquery.webfonts.test.js
@@ -34,7 +34,6 @@
 			if ( defaultFonts !== "" ) {
 				expectedResetFontFamilyList =
 					fontFamilyList( defaultFonts ).concat( expectedResetFontFamilyList );
-				console.log( expectedResetFontFamilyList );
 			}
 
 			$webfontsElement.webfonts( {


### PR DESCRIPTION
This fixes issue 5. Firefox appears to have more fine-grained control on
font configuration, which makes it return surprisng values in non-English
locales. Before this change the default font in the test suite and in
the actual element would be different if the OS locale wasn't English.
Hence, it's better to initialize the lang before initializing
tests and webfonts.
