### PR TITLE
For form fields, do not override useragent styles

### DIFF
--- a/src/jquery.webfonts.js
+++ b/src/jquery.webfonts.js
@@ -206,17 +206,18 @@
 				}
 
 				// Load and apply fonts for other language tagged elements (batched)
-				if ( element.lang && element.lang !== webfonts.language ) {
+				if ( element.lang ) {
 					// Child element's language differs from parent.
-					fontFamily = webfonts.getFont( element.lang );
+					// If there is no explicit font for this language, it will
+					// inherit the webfont for the parent.  But that is undesirable here
+					// since language is different. So inherit the original font of the
+					// element. Define it explicitly so that inheritance is broken.
 
-					if ( !fontFamily ) {
-						// If there is no explicit font for this language, it will
-						// inherit the webfont for the parent.  But that is undesirable here
-						// since language is different. So inherit the original font of the
-						// element. Define it explicitly so that inheritance is broken.
-						fontFamily = webfonts.originalFontFamily;
-					}
+					// If the language has a font, use it or use original font
+					// of the element to which this extension is applied.
+					fontFamily = webfonts.getFont( element.lang ) || fontFamily
+						||  webfonts.originalFontFamily;
+
 					// We do not have fonts for all languages
 					if ( fontFamily !== null ) {
 						append( fontQueue, fontFamily );

--- a/test/index.html
+++ b/test/index.html
@@ -17,7 +17,8 @@
 		<!-- Test Suite -->
 		<script src="jquery.webfonts.test.js"></script>
 	</head>
-	<body>
+	<body style="font-family: Sans-serif;">
 		<div id="qunit"></div>
+		<div id="qunit-fixture"></div>
 	</body>
 </html>

--- a/test/jquery.webfonts.test.js
+++ b/test/jquery.webfonts.test.js
@@ -27,7 +27,7 @@
 				$langElements,
 				localFont = 'Garamond',
 				fallbackFonts = 'Helvetica, Arial, sans-serif',
-				$qunitFixture = $( '<body>' ),
+				$qunitFixture = $( '#qunit-fixture' ),
 				// Assign lang to 'my' to make webfonts work
 				$myanmarElement = $( '<div>' ).prop( {
 					id: 'webfonts-my-fixture',
@@ -144,4 +144,100 @@
 			$myanmarElement.remove();
 		}
 	);
+
+	QUnit.test(
+		'Webfonts on mixed language html',
+		function( assert ) {
+			var testHTML = '<div lang="hi" id="#parent" ><p>Hindi text</p>'
+				+ '<div><textarea lang="ml"></textarea></div>'
+				+ '<div><textarea lang="en"></textarea></div>'
+				+ '</div>',
+				fallbackFonts = 'Helvetica, Arial, sans-serif',
+				webfontOptions = {
+					repository: {
+						languages: {
+							hi: [ 'HindiFont' ],
+							ml: [ 'MalayalamFont' ]
+						}
+					}
+				},
+				$qunitFixture = $( '#qunit-fixture' );
+			$qunitFixture.append( $( testHTML ) )
+				.webfonts( webfontOptions );
+			assert.strictEqual(
+				$qunitFixture.find( '[lang=hi]' ).css( 'font-family' ).replace( / /g, '' ),
+				// we are removing whitespaces because FF uses comma and chrome uses comma
+				// with space for fontfamily string items
+				( 'HindiFont, ' + fallbackFonts).replace( / /g, '' ),
+				'Hindi gets Hindi font'
+			);
+
+			// From where monospace comes? Browsers do weird stuff.
+			assert.strictEqual( $qunitFixture.find( '[lang=en]' ).css( 'font-family' ).replace( / /g, '' ),
+				( 'monospace,' + fallbackFonts).replace( / /g, '' ),
+				'English text area gets monospace font'
+			);
+			assert.strictEqual( $qunitFixture.find( '[lang=ml]' ).css( 'font-family' ).replace( / /g, '' ),
+				( 'MalayalamFont, ' + fallbackFonts ).replace( / /g, '' ),
+				'Malayalam textarea gets Malayalam font'
+			);
+
+			testHTML = '<div lang="en" id="#parent" ><p>English text</p>'
+				+ '<div><textarea lang="hi"></textarea></div>'
+				+ '<div><textarea lang="en"></textarea></div>'
+				+ '</div>';
+			$qunitFixture.empty().append( $( testHTML ) ).webfonts( 'refresh' );
+			assert.strictEqual( $qunitFixture.find( '[lang=hi]' ).css( 'font-family' ).replace( / /g, '' ),
+				( 'HindiFont, ' + fallbackFonts ).replace( / /g, '' ),
+				'Hindi textarea gets Hindi font'
+			) ;
+			assert.strictEqual( $qunitFixture.find( 'div[lang=en]' ).css( 'font-family' ).replace( / /g, '' ),
+				fallbackFonts.replace( / /g, '' ),
+				'English div font is fallbackFonts'
+			);
+			assert.strictEqual( $qunitFixture.find( 'textarea[lang=en]' ).css( 'font-family' ).replace( / /g, '' ),
+				( 'monospace,' + fallbackFonts).replace( / /g, '' ),
+				'English text area get monospace font'
+			);
+
+			testHTML = '<div lang="hi" id="#parent" ><p>Hindi text</p>'
+				+ '<div lang="ml"></div>'
+				+ '<div lang="en"></div>'
+				+ '</div>';
+			$qunitFixture.empty().append( $( testHTML ) ).webfonts( 'refresh' );
+			assert.strictEqual( $qunitFixture.find( '[lang=hi]' ).css( 'font-family' ).replace( / /g, '' ),
+				( 'HindiFont, ' + fallbackFonts ).replace( / /g, '' ),
+				'Hindi div gets Hindi font'
+			 );
+			assert.strictEqual( $qunitFixture.find( '[lang=en]' ).css( 'font-family' ).replace( / /g, '' ),
+				fallbackFonts.replace( / /g, '' ),
+				'English div font is fallbackFonts'
+			);
+			assert.strictEqual( $qunitFixture.find( '[lang=ml]' ).css( 'font-family' ).replace( / /g, '' ),
+				( 'MalayalamFont, ' + fallbackFonts ).replace( / /g, '' ),
+				'Malayalam div gets Malayalam font'
+			);
+
+
+			testHTML = '<div style="font-family: serif;"><p>Hindi text</p>'
+				+ '<div lang="ml"></div>'
+				+ '<div lang="en"></div>'
+				+ '<div><textarea lang="en"></textarea></div>'
+				+ '</div>';
+			$qunitFixture.empty().append( $( testHTML ) ).webfonts( 'refresh' );
+
+			assert.strictEqual( $qunitFixture.find( 'div[lang=en]' ).css( 'font-family' ).replace( / /g, '' ),
+				( 'serif, ' + fallbackFonts ).replace( / /g, '' ),
+				'English div inherits font'
+			 );
+			assert.strictEqual( $qunitFixture.find( 'textarea[lang=en]' ).css( 'font-family' ).replace( / /g, '' ),
+				( 'monospace, ' + fallbackFonts ).replace( / /g, '' ),
+				'English textarea is monospace'
+			);
+			assert.strictEqual( $qunitFixture.find( '[lang=ml]' ).css( 'font-family' ).replace( / /g, '' ),
+				( 'MalayalamFont, ' + fallbackFonts ).replace( / /g, '' ),
+				'Malayalam div gets Malayalam font'
+			);
+
+	} );
 } )( window.jQuery );


### PR DESCRIPTION
Eg: browser setting monospace font for latin language textareas
See  https://bugzilla.wikimedia.org/show_bug.cgi?id=53734
