### PR TITLE
Remove magic date from version query string

### DIFF
--- a/src/jquery.webfonts.js
+++ b/src/jquery.webfonts.js
@@ -336,7 +336,7 @@
 
 			base = this.repository.base;
 			version = fontconfig.version;
-			versionSuffix = '?version=' + version + '&20120101';
+			versionSuffix = '?version=' + version;
 			fontFaceRule = '@font-face { font-family: \'' + fontFamily + '\';\n';
 			userAgent = window.navigator.userAgent;
 			fontStyle = fontconfig.fontstyle || 'normal';


### PR DESCRIPTION
The '&20120101' component of the font URL version suffix traces back to the
first substantial code commit, 1ac3aa5ef6. I suspect it is a stray bit of debug
/ dev code that became part of the furniture after a while. Since it is fixed,
it is not causing a lot of harm, but it makes it difficult to apprehend the
browser cache invalidation strategy being used.
