### PR TITLE
Reset webfonts where we found inline css style upon reset

### DIFF
--- a/src/jquery.webfonts.js
+++ b/src/jquery.webfonts.js
@@ -118,14 +118,18 @@
 				// This will cause removing inline fontFamily style.
 			}
 
-			// Set the font of this element if it's not excluded
-			$element.not( this.options.exclude ).css( 'font-family', fontStack.join() );
+			// Set the font of this element if it's not excluded.
+			// Add class webfonts-changed when webfonts are applied.
+			$element.not( this.options.exclude )
+				.css( 'font-family', fontStack.join() )
+				.addClass( 'webfonts-changed' );
 
 			// Set the font of this element's children if they are not excluded.
 			// font-family of <input>, <textarea> and <button> must be changed explicitly.
-			$element.find( 'textarea, input, button' )
-				.not( this.options.exclude )
-				.css( 'font-family', fontStack.join() );
+			// Add class webfonts-changed when webfonts are applied.
+			$element.find( 'textarea, input, button' ).not( this.options.exclude )
+				.css( 'font-family', fontStack.join() )
+				.addClass( 'webfonts-changed' );
 		},
 
 		/**
@@ -328,6 +332,9 @@
 		 * Reset the font-family style.
 		 */
 		reset: function() {
+			this.$element.find( '.webfonts-changed' )
+				.removeClass( '.webfonts-changed' )
+				.css( 'font-family', '' );
 			this.apply( this.originalFontFamily );
 		},
 

--- a/test/jquery.webfonts.test.js
+++ b/test/jquery.webfonts.test.js
@@ -269,4 +269,47 @@
 			);
 
 	} );
+
+	QUnit.test(
+		'Webfonts apply/reset with inline css',
+		function ( assert ) {
+			var testHTML, fallbackFonts, webfontOptions, $qunitFixture;
+			testHTML = '<div class="resettest">'
+				+ '<div style="font-family: FontA,sans;"></div>'
+				+ '<span lang="gu"></span></div>';
+			fallbackFonts = 'Helvetica, Arial, sans-serif';
+			webfontOptions = {
+				repository: {
+					languages: {
+						gu: [ 'GujaratiFont' ]
+					}
+				}
+			};
+			$qunitFixture = $( '#qunit-fixture' );
+
+			$qunitFixture.append( $( testHTML ) );
+			$qunitFixture.find( '.resettest' ).webfonts( webfontOptions );
+
+			// Apply webfonts and compare webfonts applied in span.
+			assert.strictEqual( $qunitFixture.find( 'span[lang=gu]' ).css( 'font-family' ).replace( / /g, '' ),
+				( 'GujaratiFont, ' + fallbackFonts ).replace( / /g, '' ),
+				'Gujarati span gets Gujarati font after applying webfonts'
+			);
+
+			assert.strictEqual( $qunitFixture.find( 'span[lang=gu]' ).hasClass( 'webfonts-changed' ),
+				true,
+				'Gujarati span has class webfonts-changed'
+			);
+			
+			// Reset webfonts.
+			$qunitFixture.find( '.resettest' ).data( 'webfonts' ).reset();
+
+			// Compare fonts from span.
+			assert.strictEqual( $qunitFixture.find( 'span[lang=gu]' ).css( 'font-family' ).replace( / /g, '' ),
+				( fallbackFonts ).replace( / /g, '' ),
+				'Fallback font is used after reset'
+			);
+
+	} );
+
 } )( window.jQuery );


### PR DESCRIPTION
- Reset webfonts where inline css style is found upon webfont.reset()
- Added tests.
