### PR TITLE
Fix webfont application condition

### DIFF
--- a/src/jquery.webfonts.js
+++ b/src/jquery.webfonts.js
@@ -245,7 +245,7 @@
 					}
 
 					// We do not have fonts for all languages
-					if ( fontFamily !== null ) {
+					if ( fontFamily ) {
 						append( fontQueue, fontFamily );
 						elementQueue[fontFamily] = elementQueue[fontFamily] || [];
 						elementQueue[fontFamily].push( element );


### PR DESCRIPTION
When queueing elements for applying webfonts, elements are
supposed to be queued if a relevant font family was found.
If it's not found, it's undefined. The condition checked for null,
so some elements that didn't need webfonts received them.
The condition is fixed in this commit.

This fixes
https://bugzilla.wikimedia.org/show_bug.cgi?id=62530
