### PR TITLE
Fix undefined.toLowerCase is not a function in jquery.webfonts.js

### DIFF
--- a/src/jquery.webfonts.js
+++ b/src/jquery.webfonts.js
@@ -57,14 +57,14 @@
 
 		/**
 		 * Get the default font family for given language.
-		 * @param {String} language Language code.
+		 * @param {String|undefined} language Language code.
 		 * @param {array} classes
 		 * @return {String} Font family name
 		 */
 		getFont: function( language, classes ) {
-			language = ( language || this.language ).toLowerCase();
+			language = ( language || this.language || '' ).toLowerCase();
 
-			if ( this.options.fontSelector ) {
+			if ( this.options.fontSelector && language ) {
 				return this.options.fontSelector( this.repository, language, classes );
 			} else {
 				return this.repository.defaultFont( language );


### PR DESCRIPTION
The property "this.language" is not guaranteed to be set. All other places in the code using this variable check it first. This one fails.

Originally submitted to https://gerrit.wikimedia.org/r/273206.