### PR TITLE
Use correct way to get an attribute (2nd try)

### DIFF
--- a/src/jquery.webfonts.js
+++ b/src/jquery.webfonts.js
@@ -201,7 +201,7 @@
 			$elements.each( function( i, element ) {
 				var fontFamilyStyle, fontFamily,
 					$element = $( element ),
-					elementLanguage = element.attributes.lang;
+					elementLanguage = element.getAttribute( 'lang' );
 
 				if ( $element.is( webfonts.options.exclude ) ) {
 					return;


### PR DESCRIPTION
`attributes.lang` returns an `Attr` object. `getAttribute` returns a string.